### PR TITLE
カレンダー表示を削除し、シフト希望申請UIを改善

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,22 +36,12 @@
 
         <main id="mainContent" style="display: none;">
             <div class="tabs">
-                <button class="tab-button active" data-tab="calendar">カレンダー</button>
-                <button class="tab-button" data-tab="shifts">シフト一覧</button>
+                <button class="tab-button active" data-tab="shifts">シフト一覧</button>
                 <button class="tab-button" data-tab="request">シフト希望</button>
                 <button class="tab-button" data-tab="admin" id="adminTab" style="display: none;">管理者</button>
             </div>
 
-            <div id="calendarTab" class="tab-content active">
-                <div class="calendar-header">
-                    <button id="prevMonth">&lt;</button>
-                    <h2 id="currentMonth"></h2>
-                    <button id="nextMonth">&gt;</button>
-                </div>
-                <div id="calendar" class="calendar"></div>
-            </div>
-
-            <div id="shiftsTab" class="tab-content" style="display: none;">
+            <div id="shiftsTab" class="tab-content active">
                 <h2>シフト一覧</h2>
                 <div id="shiftsList" class="shifts-list"></div>
             </div>
@@ -59,15 +49,34 @@
             <div id="requestTab" class="tab-content" style="display: none;">
                 <h2>シフト希望申請</h2>
                 <form id="shiftRequestForm">
-                    <input type="date" id="requestDate" required>
-                    <select id="requestTime" required>
-                        <option value="">時間帯を選択</option>
-                        <option value="13:00-14:00">13:00-14:00</option>
-                        <option value="14:00-15:00">14:00-15:00</option>
-                        <option value="15:00-16:00">15:00-16:00</option>
-                        <option value="16:00-17:00">16:00-17:00</option>
-                        <option value="17:00-18:00">17:00-18:00</option>
+                    <select id="requestDate" required>
+                        <option value="">日付を選択してください</option>
                     </select>
+                    <div class="time-slots">
+                        <label>時間帯を選択（複数選択可）</label>
+                        <div class="checkbox-group">
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="timeSlot" value="13:00-14:00">
+                                <span>13:00-14:00</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="timeSlot" value="14:00-15:00">
+                                <span>14:00-15:00</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="timeSlot" value="15:00-16:00">
+                                <span>15:00-16:00</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="timeSlot" value="16:00-17:00">
+                                <span>16:00-17:00</span>
+                            </label>
+                            <label class="checkbox-label">
+                                <input type="checkbox" name="timeSlot" value="17:00-18:00">
+                                <span>17:00-18:00</span>
+                            </label>
+                        </div>
+                    </div>
                     <textarea id="requestNote" placeholder="備考（任意）"></textarea>
                     <button type="submit">申請</button>
                 </form>

--- a/js/app.js
+++ b/js/app.js
@@ -1,12 +1,10 @@
 let currentUser = null;
-let currentDate = new Date();
-let selectedDate = null;
 let isAdmin = false;
 
 document.addEventListener('DOMContentLoaded', () => {
     checkAuth();
     initializeEventListeners();
-    renderCalendar();
+    populateDateDropdown();
 });
 
 function initializeEventListeners() {
@@ -25,8 +23,6 @@ function initializeEventListeners() {
         button.addEventListener('click', () => switchTab(button.dataset.tab));
     });
     
-    document.getElementById('prevMonth').addEventListener('click', () => changeMonth(-1));
-    document.getElementById('nextMonth').addEventListener('click', () => changeMonth(1));
     
     document.getElementById('shiftRequestForm').addEventListener('submit', handleShiftRequest);
 }
@@ -40,6 +36,7 @@ async function checkAuth() {
         updateUserInfo();
         loadShifts();
         loadRequests();
+        populateDateDropdown();
         if (isAdmin) {
             loadAdminData();
         }
@@ -130,33 +127,39 @@ async function handleSignup(e) {
 async function handleShiftRequest(e) {
     e.preventDefault();
     const date = document.getElementById('requestDate').value;
-    const time = document.getElementById('requestTime').value;
     const note = document.getElementById('requestNote').value;
     
-    // 土日チェック
-    const requestDate = new Date(date);
-    const dayOfWeek = requestDate.getDay();
-    if (dayOfWeek === 0 || dayOfWeek === 6) {
-        alert('土日は申請できません。平日を選択してください。');
+    // チェックされた時間帯を取得
+    const checkedTimeSlots = [];
+    const checkboxes = document.querySelectorAll('input[name="timeSlot"]:checked');
+    checkboxes.forEach(checkbox => {
+        checkedTimeSlots.push(checkbox.value);
+    });
+    
+    if (checkedTimeSlots.length === 0) {
+        alert('少なくとも1つの時間帯を選択してください。');
         return;
     }
     
+    // 土日チェックは不要（プルダウンで平日のみ選択可能）
+    
     try {
+        // 選択された各時間帯に対して申請を作成
+        const insertData = checkedTimeSlots.map(timeSlot => ({
+            user_id: currentUser.id,
+            date: date,
+            time_slot: timeSlot,
+            note: note,
+            status: 'pending'
+        }));
+        
         const { data, error } = await supabase
             .from('shift_requests')
-            .insert([
-                {
-                    user_id: currentUser.id,
-                    date: date,
-                    time_slot: time,
-                    note: note,
-                    status: 'pending'
-                }
-            ]);
+            .insert(insertData);
         
         if (error) throw error;
         
-        alert('シフト希望を申請しました');
+        alert(`${checkedTimeSlots.length}件のシフト希望を申請しました`);
         document.getElementById('shiftRequestForm').reset();
         loadRequests();
     } catch (error) {
@@ -166,20 +169,15 @@ async function handleShiftRequest(e) {
 
 async function loadShifts() {
     try {
-        const startOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth(), 1).toISOString().split('T')[0];
-        const endOfMonth = new Date(currentDate.getFullYear(), currentDate.getMonth() + 1, 0).toISOString().split('T')[0];
-        
         const { data, error } = await supabase
             .from('shifts')
             .select('*')
-            .gte('date', startOfMonth)
-            .lte('date', endOfMonth)
-            .eq('user_id', currentUser.id);
+            .eq('user_id', currentUser.id)
+            .order('date', { ascending: true });
         
         if (error) throw error;
         
         displayShifts(data || []);
-        updateCalendarWithShifts(data || []);
     } catch (error) {
         console.error('シフトの読み込みに失敗しました:', error);
     }
@@ -247,87 +245,9 @@ function displayRequests(requests) {
     });
 }
 
-function renderCalendar() {
-    const calendar = document.getElementById('calendar');
-    calendar.innerHTML = '';
-    
-    const year = currentDate.getFullYear();
-    const month = currentDate.getMonth();
-    const firstDay = new Date(year, month, 1).getDay();
-    const daysInMonth = new Date(year, month + 1, 0).getDate();
-    const daysInPrevMonth = new Date(year, month, 0).getDate();
-    
-    document.getElementById('currentMonth').textContent = `${year}年${month + 1}月`;
-    
-    const dayHeaders = ['日', '月', '火', '水', '木', '金', '土'];
-    dayHeaders.forEach(day => {
-        const header = document.createElement('div');
-        header.className = 'calendar-header-day';
-        header.textContent = day;
-        header.style.fontWeight = 'bold';
-        header.style.textAlign = 'center';
-        calendar.appendChild(header);
-    });
-    
-    for (let i = firstDay - 1; i >= 0; i--) {
-        const day = document.createElement('div');
-        day.className = 'calendar-day other-month';
-        day.textContent = daysInPrevMonth - i;
-        calendar.appendChild(day);
-    }
-    
-    for (let day = 1; day <= daysInMonth; day++) {
-        const dayElement = document.createElement('div');
-        const date = new Date(year, month, day);
-        const dayOfWeek = date.getDay();
-        
-        if (dayOfWeek === 0 || dayOfWeek === 6) {
-            dayElement.className = 'calendar-day weekend';
-        } else {
-            dayElement.className = 'calendar-day';
-            dayElement.dataset.date = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
-            dayElement.addEventListener('click', () => selectDate(dayElement.dataset.date));
-        }
-        
-        dayElement.textContent = day;
-        calendar.appendChild(dayElement);
-    }
-    
-    const remainingDays = 42 - (firstDay + daysInMonth);
-    for (let day = 1; day <= remainingDays; day++) {
-        const dayElement = document.createElement('div');
-        dayElement.className = 'calendar-day other-month';
-        dayElement.textContent = day;
-        calendar.appendChild(dayElement);
-    }
-}
 
-function updateCalendarWithShifts(shifts) {
-    document.querySelectorAll('.calendar-day').forEach(day => {
-        day.classList.remove('has-shift');
-    });
-    
-    shifts.forEach(shift => {
-        const dayElement = document.querySelector(`[data-date="${shift.date}"]`);
-        if (dayElement) {
-            dayElement.classList.add('has-shift');
-        }
-    });
-}
 
-function changeMonth(direction) {
-    currentDate.setMonth(currentDate.getMonth() + direction);
-    renderCalendar();
-    loadShifts();
-}
 
-function selectDate(date) {
-    selectedDate = date;
-    document.querySelectorAll('.calendar-day').forEach(day => {
-        day.classList.remove('selected');
-    });
-    document.querySelector(`[data-date="${date}"]`).classList.add('selected');
-}
 
 function switchTab(tabName) {
     document.querySelectorAll('.tab-button').forEach(button => {
@@ -372,6 +292,8 @@ function updateUserInfo() {
             ${adminBadge}
             <button onclick="logout()">ログアウト</button>
         `;
+    } else {
+        userInfo.innerHTML = '';
     }
 }
 
@@ -379,6 +301,7 @@ async function logout() {
     await supabase.auth.signOut();
     currentUser = null;
     isAdmin = false;
+    updateUserInfo();
     showLoginForm();
 }
 
@@ -569,6 +492,47 @@ async function createShiftFromRequest(requestId) {
         
     } catch (error) {
         console.error('シフト作成に失敗しました:', error);
+    }
+}
+
+function populateDateDropdown() {
+    const dateSelect = document.getElementById('requestDate');
+    if (!dateSelect) return;
+    
+    dateSelect.innerHTML = '<option value="">日付を選択してください</option>';
+    
+    const today = new Date();
+    const currentMonth = today.getMonth();
+    const currentYear = today.getFullYear();
+    
+    // 今月の残りの平日（今日以降）
+    addWeekdaysToDropdown(dateSelect, currentYear, currentMonth, today.getDate() + 1);
+    
+    // 来月の平日
+    const nextMonth = currentMonth === 11 ? 0 : currentMonth + 1;
+    const nextYear = currentMonth === 11 ? currentYear + 1 : currentYear;
+    addWeekdaysToDropdown(dateSelect, nextYear, nextMonth, 1);
+}
+
+function addWeekdaysToDropdown(selectElement, year, month, startDay) {
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const monthNames = ['1月', '2月', '3月', '4月', '5月', '6月', '7月', '8月', '9月', '10月', '11月', '12月'];
+    
+    for (let day = startDay; day <= daysInMonth; day++) {
+        const date = new Date(year, month, day);
+        const dayOfWeek = date.getDay();
+        
+        // 土日を除外
+        if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+            const option = document.createElement('option');
+            const dateValue = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+            option.value = dateValue;
+            
+            const weekDays = ['日', '月', '火', '水', '木', '金', '土'];
+            option.textContent = `${monthNames[month]}${day}日 (${weekDays[dayOfWeek]})`;
+            
+            selectElement.appendChild(option);
+        }
     }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -87,6 +87,47 @@ button:hover {
     background-color: #2980b9;
 }
 
+.time-slots {
+    margin-bottom: 15px;
+}
+
+.time-slots > label {
+    display: block;
+    margin-bottom: 10px;
+    font-weight: 600;
+    color: #333;
+}
+
+.checkbox-group {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+}
+
+.checkbox-label {
+    display: flex;
+    align-items: center;
+    padding: 10px;
+    background-color: #f8f9fa;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.checkbox-label:hover {
+    background-color: #e9ecef;
+}
+
+.checkbox-label input[type="checkbox"] {
+    margin-right: 10px;
+    cursor: pointer;
+}
+
+.checkbox-label span {
+    font-size: 14px;
+    color: #495057;
+}
+
 .tabs {
     display: flex;
     gap: 10px;
@@ -116,65 +157,6 @@ button:hover {
     box-shadow: 0 2px 4px rgba(0,0,0,0.1);
 }
 
-.calendar-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-}
-
-.calendar-header button {
-    background-color: #ecf0f1;
-    color: #333;
-    padding: 5px 15px;
-}
-
-.calendar {
-    display: grid;
-    grid-template-columns: repeat(7, 1fr);
-    gap: 5px;
-}
-
-.calendar-day {
-    aspect-ratio: 1;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    border: 1px solid #ecf0f1;
-    border-radius: 4px;
-    cursor: pointer;
-    transition: all 0.3s;
-    font-size: 14px;
-}
-
-.calendar-day:hover {
-    background-color: #ecf0f1;
-}
-
-.calendar-day.other-month {
-    color: #bdc3c7;
-}
-
-.calendar-day.has-shift {
-    background-color: #e8f4f8;
-    border-color: #3498db;
-}
-
-.calendar-day.selected {
-    background-color: #3498db;
-    color: white;
-}
-
-.calendar-day.weekend {
-    background-color: #ecf0f1;
-    color: #95a5a6;
-    cursor: not-allowed;
-}
-
-.calendar-day.weekend:hover {
-    background-color: #ecf0f1;
-}
 
 .shifts-list {
     display: flex;
@@ -211,14 +193,17 @@ button:hover {
 
 .status-pending {
     color: #f39c12;
+    font-weight: 600;
 }
 
 .status-approved {
     color: #27ae60;
+    font-weight: 600;
 }
 
 .status-rejected {
     color: #e74c3c;
+    font-weight: 600;
 }
 
 .admin-section {
@@ -315,7 +300,4 @@ button:hover {
         flex-direction: column;
     }
     
-    .calendar {
-        font-size: 12px;
-    }
 }


### PR DESCRIPTION
## Summary
- カレンダータブを削除し、シフト一覧をデフォルトタブに設定
- シフト希望申請で複数の時間帯を一度に選択できるように改善
- 日付選択をプルダウン形式に変更（平日のみ選択可能）

## Test plan
- [ ] シフト一覧がデフォルトで表示されることを確認
- [ ] シフト希望申請で複数の時間帯を選択できることを確認
- [ ] 日付プルダウンに平日のみが表示されることを確認
- [ ] 複数時間帯の申請が正しく保存されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)